### PR TITLE
S20-2774 feat: Add filesExist method to UploadService for file existe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.96.65
+
+* Added new method ::filesExist to UploadService:
+
 ## 1.96.2
 
 * Fixed wrong endpoint used:

--- a/src/Services/UploadService.php
+++ b/src/Services/UploadService.php
@@ -21,9 +21,4 @@ class UploadService extends ShekelBaseService {
         $url = "/";
         return $this->handleRequest($this->client->get($url, $data));
     }
-
-    public function filesExist($data) {
-        $url = "/files/exists";
-        return $this->handleRequest($this->client->post($url, $data));
-    }
 }

--- a/src/Services/UploadService.php
+++ b/src/Services/UploadService.php
@@ -21,4 +21,9 @@ class UploadService extends ShekelBaseService {
         $url = "/";
         return $this->handleRequest($this->client->get($url, $data));
     }
+
+    public function filesExist($data) {
+        $url = "/files/exists";
+        return $this->handleRequest($this->client->post($url, $data));
+    }
 }

--- a/src/Services/v3/UploadService.php
+++ b/src/Services/v3/UploadService.php
@@ -21,7 +21,7 @@ class UploadService extends ShekelBaseService {
     }
 
     public function filesExist($data) {
-        $url = "/files/exists";
+        $url = "/files/exist";
         return $this->handleRequest($this->client->post($url, $data));
     }
 }

--- a/src/Services/v3/UploadService.php
+++ b/src/Services/v3/UploadService.php
@@ -19,4 +19,9 @@ class UploadService extends ShekelBaseService {
         $url = "/";
         return $this->handleRequest($this->client->get($url, $data));
     }
+
+    public function filesExist($data) {
+        $url = "/files/exists";
+        return $this->handleRequest($this->client->post($url, $data));
+    }
 }


### PR DESCRIPTION
This PR adds a new method, `filesExist`, to the `UploadService` class, which makes a request to the new route in Upload-API.

**How to test**
- install the package and call the method for files that exist in the S3 bucket